### PR TITLE
feat: One DB support

### DIFF
--- a/src/entities/HistoryData.entity.ts
+++ b/src/entities/HistoryData.entity.ts
@@ -5,7 +5,7 @@ import { PrimaryColumn } from 'typeorm/decorator/columns/PrimaryColumn'
 export class HistoryData {
   /** @dev This is NOT the sourceChainId, this is the chain the service is running on (to avoid having multiple databases) */
   @PrimaryColumn({ type: 'int', name: 'service_chain_id' })
-  serviceChainId: string | number;
+  serviceChainId: string | number
 
   @PrimaryColumn({ type: 'int', name: 'deposit_chain_id' })
   depositChainId: string | number

--- a/src/entities/HistoryData.entity.ts
+++ b/src/entities/HistoryData.entity.ts
@@ -3,9 +3,13 @@ import { PrimaryColumn } from 'typeorm/decorator/columns/PrimaryColumn'
 
 @Entity({ name: 'history_data' })
 export class HistoryData {
-  @PrimaryColumn({ type: 'int', name: 'chain_id' })
-  chainId: string | number
+  /** @dev This is NOT the sourceChainId, this is the chain the service is running on (to avoid having multiple databases) */
+  @PrimaryColumn({ type: 'int', name: 'service_chain_id' })
+  serviceChainId: string | number;
 
-  @Column({ type: 'int', name: 'block_no' })
-  blockNo: number
+  @PrimaryColumn({ type: 'int', name: 'deposit_chain_id' })
+  depositChainId: string | number
+
+  @Column({ type: 'int', name: 'deposit_block_no' })
+  depositBlockNo: number
 }

--- a/src/entities/LastAirdrop.entity.ts
+++ b/src/entities/LastAirdrop.entity.ts
@@ -3,6 +3,10 @@ import { PrimaryColumn } from 'typeorm/decorator/columns/PrimaryColumn'
 
 @Entity({ name: 'last_airdrop' })
 export class LastAirdrop {
+  /** @dev This is NOT the sourceChainId, this is the chain the service is running on (to avoid having multiple databases) */
+  @PrimaryColumn({ type: 'int', name: 'service_chain_id' })
+  serviceChainId: string | number;
+
   /** @dev Chain independent to be more resilient */
   @PrimaryColumn({ type: 'varchar', name: 'wallet_addr' })
   walletAddr: string

--- a/src/entities/LastAirdrop.entity.ts
+++ b/src/entities/LastAirdrop.entity.ts
@@ -5,7 +5,7 @@ import { PrimaryColumn } from 'typeorm/decorator/columns/PrimaryColumn'
 export class LastAirdrop {
   /** @dev This is NOT the sourceChainId, this is the chain the service is running on (to avoid having multiple databases) */
   @PrimaryColumn({ type: 'int', name: 'service_chain_id' })
-  serviceChainId: string | number;
+  serviceChainId: string | number
 
   /** @dev Chain independent to be more resilient */
   @PrimaryColumn({ type: 'varchar', name: 'wallet_addr' })

--- a/src/service.ts
+++ b/src/service.ts
@@ -66,7 +66,6 @@ interface TeleportationOptions {
 const optionSettings = {}
 
 export class LightBridgeService extends BaseService<TeleportationOptions> {
-
   constructor(options: TeleportationOptions) {
     super('Teleportation', options, optionSettings)
   }
@@ -190,8 +189,6 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
   }
 
   protected async _start(): Promise<void> {
-    // to avoid having multiple databases and have multiple instances run in parallel in the same container
-    const serviceChainId = this.options.chainId;
 
     while (this.running) {
       for (const depositTeleportation of this.state.depositTeleportations) {
@@ -397,7 +394,9 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
         sliceEnd = Math.min(sliceEnd + 10, numberOfDisbursement)
       }
       this.logger.info(
-        `Disbursement successful - serviceChainId: ${this.options.chainId} - depositChainId: ${depositChainId} - slicedDisbursement:${JSON.stringify(
+        `Disbursement successful - serviceChainId: ${
+          this.options.chainId
+        } - depositChainId: ${depositChainId} - slicedDisbursement:${JSON.stringify(
           disbursement
         )} - latestBlock: ${latestBlock}`
       )
@@ -408,7 +407,9 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
       if (this.options.airdropConfig?.airdropEnabled) {
         await this._airdropGas(disbursement, latestBlock)
       } else {
-        this.logger.info(`Gas airdrop is disabled on chainId: ${depositChainId}.`)
+        this.logger.info(
+          `Gas airdrop is disabled on chainId: ${depositChainId}.`
+        )
       }
     } catch (e) {
       this.logger.error(e)
@@ -566,7 +567,10 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
       historyData.depositChainId = depositChainId
       historyData.depositBlockNo = latestBlock
       if (
-        await historyDataRepository.findOneBy({ depositChainId, serviceChainId: this.options.chainId })
+        await historyDataRepository.findOneBy({
+          depositChainId,
+          serviceChainId: this.options.chainId,
+        })
       ) {
         await historyDataRepository.update(
           { depositChainId, serviceChainId: this.options.chainId },

--- a/src/service.ts
+++ b/src/service.ts
@@ -66,6 +66,7 @@ interface TeleportationOptions {
 const optionSettings = {}
 
 export class LightBridgeService extends BaseService<TeleportationOptions> {
+
   constructor(options: TeleportationOptions) {
     super('Teleportation', options, optionSettings)
   }
@@ -189,6 +190,9 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
   }
 
   protected async _start(): Promise<void> {
+    // to avoid having multiple databases and have multiple instances run in parallel in the same container
+    const serviceChainId = this.options.chainId;
+
     while (this.running) {
       for (const depositTeleportation of this.state.depositTeleportations) {
         // search AssetReceived events
@@ -222,14 +226,14 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
     latestBlock: number
   ): Promise<AssetReceivedEvent[]> {
     let lastBlock: number
-    const chainId = depositTeleportation.chainId.toString()
+    const depositChainId = depositTeleportation.chainId.toString()
     try {
-      lastBlock = await this._getDepositInfo(chainId)
+      lastBlock = await this._getDepositInfo(depositChainId)
     } catch (e) {
-      this.logger.warn(`No deposit info found in chainId - ${chainId}`)
+      this.logger.warn(`No deposit info found in chainId - ${depositChainId}`)
       lastBlock = depositTeleportation.height
       // store the new deposit info
-      await this._putDepositInfo(chainId, lastBlock)
+      await this._putDepositInfo(depositChainId, lastBlock)
     }
     return this._getEvents(
       depositTeleportation.Teleportation,
@@ -244,14 +248,14 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
     events: AssetReceivedEvent[],
     latestBlock: number
   ): Promise<void> {
-    const chainId = depositTeleportation.chainId
+    const depositChainId = depositTeleportation.chainId
     // parse events
     if (events.length === 0) {
       // update the deposit info if no events are found
-      await this._putDepositInfo(chainId, latestBlock)
+      await this._putDepositInfo(depositChainId, latestBlock)
     } else {
       const lastDisbursement =
-        await this.state.Teleportation.totalDisbursements(chainId)
+        await this.state.Teleportation.totalDisbursements(depositChainId)
       // eslint-disable-next-line prefer-const
       let disbursement: Disbursement[] = []
 
@@ -311,13 +315,13 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
           // sort disbursement
           disbursement = orderBy(disbursement, ['depositId'], ['asc'])
           // disbure the token but only if all disbursements could have been processed to avoid missing events due to updating the latestBlock
-          await this._disburseTx(disbursement, chainId, latestBlock)
+          await this._disburseTx(disbursement, depositChainId, latestBlock)
         } else {
           this.logger.info(
             'No suitable disbursement event for current network',
-            { chainId }
+            { depositChainId, serviceChainId: this.options.chainId }
           )
-          await this._putDepositInfo(chainId, latestBlock)
+          await this._putDepositInfo(depositChainId, latestBlock)
         }
       } catch (e) {
         // Catch outside loop to stop at first failing depositID as all subsequent disbursements as depositId = amountDisbursements and would fail when disbursing
@@ -328,7 +332,7 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
 
   async _disburseTx(
     disbursement: Disbursement[],
-    chainId: number,
+    depositChainId: number,
     latestBlock: number
   ): Promise<void> {
     try {
@@ -393,18 +397,18 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
         sliceEnd = Math.min(sliceEnd + 10, numberOfDisbursement)
       }
       this.logger.info(
-        `Disbursement successful - chainId: ${chainId} - slicedDisbursement:${JSON.stringify(
+        `Disbursement successful - serviceChainId: ${this.options.chainId} - depositChainId: ${depositChainId} - slicedDisbursement:${JSON.stringify(
           disbursement
         )} - latestBlock: ${latestBlock}`
       )
 
-      await this._putDepositInfo(chainId, latestBlock)
+      await this._putDepositInfo(depositChainId, latestBlock)
 
       // Only do on boba l2
       if (this.options.airdropConfig?.airdropEnabled) {
         await this._airdropGas(disbursement, latestBlock)
       } else {
-        this.logger.info(`Gas airdrop is disabled on chainId: ${chainId}.`)
+        this.logger.info(`Gas airdrop is disabled on chainId: ${depositChainId}.`)
       }
     } catch (e) {
       this.logger.error(e)
@@ -439,6 +443,7 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
       if (await this._fulfillsAirdropConditions(disbursement)) {
         const lastAirdrop = await lastAirdropRepository.findOneBy({
           walletAddr: disbursement.addr,
+          serviceChainId: this.options.chainId,
         })
         const unixTimestamp = Math.floor(Date.now() / 1000)
 
@@ -469,6 +474,7 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
             await this.state.Teleportation.provider.getBlock('latest')
           )?.timestamp
           const newAirdrop = new LastAirdrop()
+          newAirdrop.serviceChainId = this.options.chainId
           newAirdrop.blockTimestamp = blockNumber
           newAirdrop.walletAddr = disbursement.addr
           await lastAirdropRepository.save(newAirdrop)
@@ -551,18 +557,19 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
   }
 
   async _putDepositInfo(
-    chainId: number | string,
+    depositChainId: number | string,
     latestBlock: number
   ): Promise<void> {
     try {
       const historyData = new HistoryData()
-      historyData.chainId = chainId
-      historyData.blockNo = latestBlock
+      historyData.serviceChainId = this.options.chainId
+      historyData.depositChainId = depositChainId
+      historyData.depositBlockNo = latestBlock
       if (
-        await historyDataRepository.findOneBy({ chainId: historyData.chainId })
+        await historyDataRepository.findOneBy({ depositChainId, serviceChainId: this.options.chainId })
       ) {
         await historyDataRepository.update(
-          { chainId: historyData.chainId },
+          { depositChainId, serviceChainId: this.options.chainId },
           historyData
         )
       } else {
@@ -575,11 +582,11 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
 
   async _getDepositInfo(chainId: number | string): Promise<number> {
     const historyData = await historyDataRepository.findOneBy({
-      chainId,
+      depositChainId: chainId,
     })
 
     if (historyData) {
-      return historyData.blockNo
+      return historyData.depositBlockNo
     } else {
       throw new Error("Can't find latestBlock in depositInfo")
     }

--- a/test/lightbridge.integration.spec.ts
+++ b/test/lightbridge.integration.spec.ts
@@ -242,18 +242,15 @@ describe('lightbridge', () => {
       await teleportationService.init()
 
       const blockNumber = await provider.getBlockNumber()
-      console.warn('BLOKKKKK', blockNumber)
       const events = await teleportationService._getEvents(
         LightBridge,
         LightBridge.filters.AssetReceived(),
         0,
         blockNumber
       )
-      console.warn('EVEN:LLL', events.length)
 
       expect(events.length).to.be.gt(0, 'Event length must be greater than 0')
 
-      console.warn('EVENT LENGTH', events.length, JSON.stringify(events))
       let disbursement = []
       for (const event of events) {
         const sourceChainId = event.args.sourceChainId
@@ -278,14 +275,11 @@ describe('lightbridge', () => {
 
       const preBOBABalance = await L2BOBA.balanceOf(address1)
       const preSignerBOBABalance = await L2BOBA.balanceOf(signerAddr)
-      console.warn('PRE BAL: ', preBOBABalance, preSignerBOBABalance)
 
       await teleportationService._disburseTx(disbursement, chainId, blockNumber)
 
       const postBOBABalance = await L2BOBA.balanceOf(address1)
       const postSignerBOBABalance = await L2BOBA.balanceOf(signerAddr)
-
-      console.warn('POST BAL: ', postBOBABalance, postSignerBOBABalance)
 
       expect(preBOBABalance.sub(postBOBABalance)).to.be.eq(
         utils.parseEther('10')
@@ -584,7 +578,7 @@ describe('lightbridge', () => {
       const teleportationService = await startLightBridgeService()
       await teleportationService.init()
 
-      await historyDataRepository.delete({ chainId })
+      await historyDataRepository.delete({ depositChainId: chainId })
 
       const latestBlock = await provider.getBlockNumber()
       const depositTeleportations = {
@@ -736,6 +730,7 @@ describe('lightbridge', () => {
 
       const teleportationServiceEth = await startLightBridgeService(false)
       await teleportationServiceEth.init()
+
 
       let disbursement = []
       for (const event of events) {

--- a/test/lightbridge.integration.spec.ts
+++ b/test/lightbridge.integration.spec.ts
@@ -731,7 +731,6 @@ describe('lightbridge', () => {
       const teleportationServiceEth = await startLightBridgeService(false)
       await teleportationServiceEth.init()
 
-
       let disbursement = []
       for (const event of events) {
         const sourceChainId = chainIdBobaBnb // event.args.sourceChainId -> (is correct, but we were mocking a fake chainId for testing)


### PR DESCRIPTION
# Use 1 DB for all services

Right now the Backend service needs to be deployed per network, as well as the database. 

This is just a waste of infra budget. 

This first PR should remove the necessity to deploy a dedicated database for each service. 

Please carefully review. All Tests run through. 

--

The next PR ideally merges all services into one container to save even more infra costs. 