### PR TITLE
feat: Add Prod mode for AWS KMS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# dev = development, prod = productive
+LIGHTBRIDGE_ENV=dev
 # dev=false, prod=true
 LIGHTBRIDGE_REJECT_UNAUTHORIZED=false
 # Main rpc this service is running on
@@ -37,4 +39,5 @@ LIGHTBRIDGE_AIRDROP_ENABLED=false
 # Optional
 LIGHTBRIDGE_POLLING_INTERVAL=
 LIGHTBRIDGE_BLOCK_RANGE_PER_POLLING=
+
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ All configuration is done via environment variables. See all variables at [.env.
 | LIGHTBRIDGE_POSTGRES_DB                 | The database name                                  | postgres        |
 | LIGHTBRIDGE_POSTGRES_PORT               | The database port                                  | 5432            |
 | LIGHTBRIDGE_POSTGRES_USER               | The database user                                  | postgres        |
+| LIGHTBRIDGE_ENV                         | The environment mode (dev or prod)                 | dev             |
 
 ## Building & Running
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -24,6 +24,7 @@ services:
       RPC_URL: "http://anvil:8545"
       LIGHTBRIDGE_REJECT_UNAUTHORIZED: "true"
       # KMS setup (incl. defaults)
+      LIGHTBRIDGE_ENV: "dev"
       LIGHTBRIDGE_AWS_KMS_ACCESS_KEY: "1"
       LIGHTBRIDGE_AWS_KMS_SECRET_KEY: "2"
       LIGHTBRIDGE_AWS_KMS_KEY_ID: "lb_disburser_pk"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     environment:
       RPC_URL: "${RPC_URL:-https://replica.goerli.boba.network}"
       # KMS setup (incl. defaults)
+      LIGHTBRIDGE_ENV: "dev"
       LIGHTBRIDGE_AWS_KMS_ACCESS_KEY: "${LIGHTBRIDGE_AWS_KMS_ACCESS_KEY:-1}"
       LIGHTBRIDGE_AWS_KMS_SECRET_KEY: "${LIGHTBRIDGE_AWS_KMS_SECRET_KEY:-2}"
       LIGHTBRIDGE_AWS_KMS_KEY_ID: "${LIGHTBRIDGE_AWS_KMS_KEY_ID:-lb_disburser_pk}"

--- a/src/exec/run.ts
+++ b/src/exec/run.ts
@@ -100,12 +100,12 @@ const main = async () => {
     throw new Error('Must pass RPC_URL')
   }
   if (
-    envModeIsDevelopment && (
-    !LIGHTBRIDGE_AWS_KMS_ACCESS_KEY ||
-    !LIGHTBRIDGE_AWS_KMS_SECRET_KEY ||
-    !LIGHTBRIDGE_AWS_KMS_KEY_ID ||
-    !LIGHTBRIDGE_AWS_KMS_ENDPOINT ||
-    !LIGHTBRIDGE_AWS_KMS_REGION)
+    envModeIsDevelopment &&
+    (!LIGHTBRIDGE_AWS_KMS_ACCESS_KEY ||
+      !LIGHTBRIDGE_AWS_KMS_SECRET_KEY ||
+      !LIGHTBRIDGE_AWS_KMS_KEY_ID ||
+      !LIGHTBRIDGE_AWS_KMS_ENDPOINT ||
+      !LIGHTBRIDGE_AWS_KMS_REGION)
   ) {
     throw new Error('Must pass TELEPORTATION AWS CONFIG ENV')
   }

--- a/src/exec/run.ts
+++ b/src/exec/run.ts
@@ -100,11 +100,12 @@ const main = async () => {
     throw new Error('Must pass RPC_URL')
   }
   if (
+    envModeIsDevelopment && (
     !LIGHTBRIDGE_AWS_KMS_ACCESS_KEY ||
     !LIGHTBRIDGE_AWS_KMS_SECRET_KEY ||
     !LIGHTBRIDGE_AWS_KMS_KEY_ID ||
     !LIGHTBRIDGE_AWS_KMS_ENDPOINT ||
-    !LIGHTBRIDGE_AWS_KMS_REGION
+    !LIGHTBRIDGE_AWS_KMS_REGION)
   ) {
     throw new Error('Must pass TELEPORTATION AWS CONFIG ENV')
   }

--- a/src/exec/run.ts
+++ b/src/exec/run.ts
@@ -41,7 +41,7 @@ const main = async () => {
   const env = process.env
 
   if (env.LIGHTBRIDGE_ENV !== 'dev' && env.LIGHTBRIDGE_ENV !== 'prod') {
-    throw Error("must define env: LIGHTBRIDGE_ENV either dev or prod")
+    throw Error('must define env: LIGHTBRIDGE_ENV either dev or prod')
   }
 
   const envModeIsDevelopment = env.LIGHTBRIDGE_ENV === 'dev'
@@ -141,11 +141,17 @@ const main = async () => {
     pollingInterval: POLLING_INTERVAL,
     blockRangePerPolling: BLOCK_RANGE_PER_POLLING,
     awsConfig: {
-      awsKmsAccessKey: envModeIsDevelopment ? LIGHTBRIDGE_AWS_KMS_ACCESS_KEY : null ,
-      awsKmsSecretKey: envModeIsDevelopment ? LIGHTBRIDGE_AWS_KMS_SECRET_KEY : null,
+      awsKmsAccessKey: envModeIsDevelopment
+        ? LIGHTBRIDGE_AWS_KMS_ACCESS_KEY
+        : null,
+      awsKmsSecretKey: envModeIsDevelopment
+        ? LIGHTBRIDGE_AWS_KMS_SECRET_KEY
+        : null,
       awsKmsKeyId: LIGHTBRIDGE_AWS_KMS_KEY_ID,
       awsKmsRegion: LIGHTBRIDGE_AWS_KMS_REGION,
-      awsKmsEndpoint: envModeIsDevelopment ? LIGHTBRIDGE_AWS_KMS_ENDPOINT : null,
+      awsKmsEndpoint: envModeIsDevelopment
+        ? LIGHTBRIDGE_AWS_KMS_ENDPOINT
+        : null,
     },
     airdropConfig: {
       airdropAmountWei: LIGHTBRIDGE_AIRDROP_GAS_AMOUNT_WEI,

--- a/src/exec/run.ts
+++ b/src/exec/run.ts
@@ -39,6 +39,13 @@ const main = async () => {
   })
 
   const env = process.env
+
+  if (env.LIGHTBRIDGE_ENV !== 'dev' && env.LIGHTBRIDGE_ENV !== 'prod') {
+    throw Error("must define env: LIGHTBRIDGE_ENV either dev or prod")
+  }
+
+  const envModeIsDevelopment = env.LIGHTBRIDGE_ENV === 'dev'
+
   const RPC_URL = config.str('l2-node-web3-url', env.RPC_URL)
   // This private key is used to send funds to the contract and initiate the tx,
   // so it should have enough BOBA balance
@@ -134,11 +141,11 @@ const main = async () => {
     pollingInterval: POLLING_INTERVAL,
     blockRangePerPolling: BLOCK_RANGE_PER_POLLING,
     awsConfig: {
-      awsKmsAccessKey: LIGHTBRIDGE_AWS_KMS_ACCESS_KEY,
-      awsKmsSecretKey: LIGHTBRIDGE_AWS_KMS_SECRET_KEY,
+      awsKmsAccessKey: envModeIsDevelopment ? LIGHTBRIDGE_AWS_KMS_ACCESS_KEY : null ,
+      awsKmsSecretKey: envModeIsDevelopment ? LIGHTBRIDGE_AWS_KMS_SECRET_KEY : null,
       awsKmsKeyId: LIGHTBRIDGE_AWS_KMS_KEY_ID,
       awsKmsRegion: LIGHTBRIDGE_AWS_KMS_REGION,
-      awsKmsEndpoint: LIGHTBRIDGE_AWS_KMS_ENDPOINT,
+      awsKmsEndpoint: envModeIsDevelopment ? LIGHTBRIDGE_AWS_KMS_ENDPOINT : null,
     },
     airdropConfig: {
       airdropAmountWei: LIGHTBRIDGE_AIRDROP_GAS_AMOUNT_WEI,

--- a/src/service.ts
+++ b/src/service.ts
@@ -86,7 +86,7 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
     })
 
     this.logger.info('Initializing KMSSigner...')
-    this.state.KMSSigner = new KMSSigner(this.options.awsConfig)
+    this.state.KMSSigner = new KMSSigner(this.options.awsConfig, process.env.LIGHTBRIDGE_ENV === 'dev')
 
     this.logger.info('Connecting to Teleportation contract...')
     this.state.Teleportation = await getBobaContractAt(

--- a/src/service.ts
+++ b/src/service.ts
@@ -86,7 +86,10 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
     })
 
     this.logger.info('Initializing KMSSigner...')
-    this.state.KMSSigner = new KMSSigner(this.options.awsConfig, process.env.LIGHTBRIDGE_ENV === 'dev')
+    this.state.KMSSigner = new KMSSigner(
+      this.options.awsConfig,
+      process.env.LIGHTBRIDGE_ENV === 'dev'
+    )
 
     this.logger.info('Connecting to Teleportation contract...')
     this.state.Teleportation = await getBobaContractAt(

--- a/src/utils/kms-signing.ts
+++ b/src/utils/kms-signing.ts
@@ -21,8 +21,8 @@ import {
 export interface IKMSSignerConfig {
   awsKmsEndpoint: string
   awsKmsRegion: string
-  awsKmsAccessKey: string
-  awsKmsSecretKey: string
+  awsKmsAccessKey?: string
+  awsKmsSecretKey?: string
   awsKmsKeyId: string
   /** @dev Should always be enabled, but can be helpful for debugging and unit tests, .. */
   disableDisburserCheck?: boolean
@@ -32,7 +32,7 @@ export class KMSSigner {
   private kmsClient: KMSClient
   private readonly kmsKeyId: string
 
-  constructor(kmsSignerConfig: IKMSSignerConfig) {
+  constructor(kmsSignerConfig: IKMSSignerConfig, isDevelopment = true) {
     const {
       awsKmsEndpoint,
       awsKmsKeyId,
@@ -40,14 +40,21 @@ export class KMSSigner {
       awsKmsSecretKey,
       awsKmsAccessKey,
     } = kmsSignerConfig
-    this.kmsClient = new KMSClient({
-      region: awsKmsRegion,
-      endpoint: awsKmsEndpoint,
-      credentials: {
-        accessKeyId: awsKmsAccessKey, // credentials for your IAM user with KMS access
-        secretAccessKey: awsKmsSecretKey, // credentials for your IAM user with KMS access
-      },
-    })
+    if (isDevelopment) {
+      this.kmsClient = new KMSClient({
+        region: awsKmsRegion,
+        endpoint: awsKmsEndpoint,
+        credentials: {
+          accessKeyId: awsKmsAccessKey, // credentials for your IAM user with KMS access
+          secretAccessKey: awsKmsSecretKey, // credentials for your IAM user with KMS access
+        },
+      })
+    } else {
+      this.kmsClient = new KMSClient({
+        region: awsKmsRegion
+      })
+    }
+
     this.kmsKeyId = awsKmsKeyId
   }
 

--- a/src/utils/kms-signing.ts
+++ b/src/utils/kms-signing.ts
@@ -51,7 +51,7 @@ export class KMSSigner {
       })
     } else {
       this.kmsClient = new KMSClient({
-        region: awsKmsRegion
+        region: awsKmsRegion,
       })
     }
 


### PR DESCRIPTION
Devmode still works, but couldn't test for production. 

Feedback welcome. @jyoti-enya @boyuan-chen 

Based on https://github.com/bobanetwork/v3-anchorage/pull/104/files

New env: 
`LIGHTBRIDGE_ENV` if set to `prod` then production config as in Go can be used. 