### PR TITLE
chore: Cleanup of comment

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -93,11 +93,7 @@ export class LightBridgeService extends BaseService<TeleportationOptions> {
       this.options.teleportationAddress,
       LightBridgeABI.abi,
       this.options.l2RpcProvider
-    ) /*await getBobaContractAt(
-      'Teleportation',
-      this.options.teleportationAddress,
-      this.options.l2RpcProvider
-    )*/
+    )
 
     this.logger.info('Connected to Teleportation', {
       address: this.state.Teleportation.address,


### PR DESCRIPTION
# Removal of Dead Code
 
Description
In the process of initializing the Teleportation contract instance using a direct Contract constructor with LightBridgeABI.abi and this.options.l2RpcProvider, an alternative method for obtaining the contract instance (getBobaContractAt) is commented out and left within the codebase. This commented-out portion constitutes dead code, which, while not executed, clutters the codebase and may lead to confusion or misinterpretation regarding the intended method for contract instantiation.
File(s)