### PR TITLE
chore: Query via depositId instead of blocks

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -285,8 +285,9 @@ export class LightBridgeService extends BaseService<LightBridgeOptions> {
       await this._putDepositInfo(depositChainId, lastBlock)
     }
 
-    const lastDisbursement =
-      await this.state.Teleportation.totalDisbursements(depositChainId)
+    const lastDisbursement = await this.state.Teleportation.totalDisbursements(
+      depositChainId
+    )
 
     return this._getAssetReceivedEvents(
       depositTeleportation.chainId,
@@ -294,7 +295,7 @@ export class LightBridgeService extends BaseService<LightBridgeOptions> {
       lastBlock,
       latestBlock,
       depositTeleportation.Teleportation,
-      lastDisbursement,
+      lastDisbursement
     )
   }
 
@@ -313,7 +314,10 @@ export class LightBridgeService extends BaseService<LightBridgeOptions> {
         await this.state.Teleportation.totalDisbursements(depositChainId)
       // eslint-disable-next-line prefer-const
       let disbursement: Disbursement[] = []
-      this.logger.info(`Found ${events.length} events for disbursement`, {depositIds: events.map((e) => e.depositId), serviceChainId: this.options.chainId})
+      this.logger.info(`Found ${events.length} events for disbursement`, {
+        depositIds: events.map((e) => e.depositId),
+        serviceChainId: this.options.chainId,
+      })
 
       try {
         for (const event of events) {
@@ -572,7 +576,8 @@ export class LightBridgeService extends BaseService<LightBridgeOptions> {
       )
       if (disbursements.length > 0 && !nextDisbursement) {
         this.logger.error(
-          `Could NOT recover DB state, RESETTING block number for next startup to get system back up running.`, {disbursements, nextDepositIds}
+          `Could NOT recover DB state, RESETTING block number for next startup to get system back up running.`,
+          { disbursements, nextDepositIds }
         )
         await this._putDepositInfo(
           sourceChainId,
@@ -771,9 +776,9 @@ export class LightBridgeService extends BaseService<LightBridgeOptions> {
         sourceChainId,
         targetChainId,
         null,
-        null, // fromBlock,
-        null, // toBlock,
-        lastDisbursement?.toString(), // should reduce amount of invalid events
+        lastDisbursement ? null : fromBlock, // prefer lastDisbursement over blockRange
+        lastDisbursement ? null : toBlock, // prefer lastDisbursement over blockRange
+        lastDisbursement?.toString() // should reduce amount of invalid events
       )
     } catch (err) {
       this.logger.warn(`Caught GraphQL error!`, { errMsg: err?.message, err })

--- a/src/service.ts
+++ b/src/service.ts
@@ -285,12 +285,16 @@ export class LightBridgeService extends BaseService<LightBridgeOptions> {
       await this._putDepositInfo(depositChainId, lastBlock)
     }
 
+    const lastDisbursement =
+      await this.state.Teleportation.totalDisbursements(depositChainId)
+
     return this._getAssetReceivedEvents(
       depositTeleportation.chainId,
       this.options.chainId,
       lastBlock,
       latestBlock,
-      depositTeleportation.Teleportation
+      depositTeleportation.Teleportation,
+      lastDisbursement,
     )
   }
 
@@ -757,7 +761,8 @@ export class LightBridgeService extends BaseService<LightBridgeOptions> {
     targetChainId: number,
     fromBlock: number,
     toBlock: number,
-    contract?: Contract
+    contract?: Contract,
+    lastDisbursement?: BigNumber
   ): Promise<LightBridgeAssetReceivedEvent[]> {
     let events: LightBridgeAssetReceivedEvent[]
 
@@ -766,8 +771,9 @@ export class LightBridgeService extends BaseService<LightBridgeOptions> {
         sourceChainId,
         targetChainId,
         null,
-        fromBlock,
-        toBlock
+        null, // fromBlock,
+        null, // toBlock,
+        lastDisbursement?.toString(), // should reduce amount of invalid events
       )
     } catch (err) {
       this.logger.warn(`Caught GraphQL error!`, { errMsg: err?.message, err })

--- a/test/lightbridge.integration.spec.ts
+++ b/test/lightbridge.integration.spec.ts
@@ -380,7 +380,9 @@ describe('lightbridge', () => {
       const startBlockNumber = await provider.getBlockNumber()
 
       // deposit token
-      const lastDisbursement = await LightBridge.connect(signer).totalDisbursements(chainId)
+      const lastDisbursement = await LightBridge.connect(
+        signer
+      ).totalDisbursements(chainId)
       for (let i = 0; i < 15; i++) {
         await L2BOBA.approve(LightBridge.address, utils.parseEther('10'))
         const res = await LightBridge.connect(signer).teleportAsset(
@@ -399,7 +401,7 @@ describe('lightbridge', () => {
         startBlockNumber,
         endBlockNumber,
         null,
-        lastDisbursement,
+        lastDisbursement
       )
 
       expect(latestEvents.length).to.be.eq(15)
@@ -1197,7 +1199,9 @@ describe('lightbridge', () => {
       await res.wait()
       await waitForSubgraph()
 
-      const lastDisbursement = await LightBridge.totalDisbursements(chainIdBobaBnb)
+      const lastDisbursement = await LightBridgeBNB.totalDisbursements(
+        chainId
+      )
       const blockNumber = await providerBnb.getBlockNumber()
       const events = await teleportationServiceBnb._getAssetReceivedEvents(
         chainIdBobaBnb,

--- a/test/lightbridge.integration.spec.ts
+++ b/test/lightbridge.integration.spec.ts
@@ -1199,17 +1199,12 @@ describe('lightbridge', () => {
       await res.wait()
       await waitForSubgraph()
 
-      const lastDisbursement = await LightBridgeBNB.totalDisbursements(
-        chainId
-      )
       const blockNumber = await providerBnb.getBlockNumber()
       const events = await teleportationServiceBnb._getAssetReceivedEvents(
         chainIdBobaBnb,
         chainId,
         preBlockNumber,
         blockNumber,
-        null,
-        lastDisbursement
       )
 
       console.log(

--- a/test/lightbridge.integration.spec.ts
+++ b/test/lightbridge.integration.spec.ts
@@ -380,6 +380,7 @@ describe('lightbridge', () => {
       const startBlockNumber = await provider.getBlockNumber()
 
       // deposit token
+      const lastDisbursement = await LightBridge.connect(signer).totalDisbursements(chainId)
       for (let i = 0; i < 15; i++) {
         await L2BOBA.approve(LightBridge.address, utils.parseEther('10'))
         const res = await LightBridge.connect(signer).teleportAsset(
@@ -396,7 +397,9 @@ describe('lightbridge', () => {
         chainId,
         chainId,
         startBlockNumber,
-        endBlockNumber
+        endBlockNumber,
+        null,
+        lastDisbursement,
       )
 
       expect(latestEvents.length).to.be.eq(15)
@@ -1194,12 +1197,15 @@ describe('lightbridge', () => {
       await res.wait()
       await waitForSubgraph()
 
+      const lastDisbursement = await LightBridge.totalDisbursements(chainIdBobaBnb)
       const blockNumber = await providerBnb.getBlockNumber()
       const events = await teleportationServiceBnb._getAssetReceivedEvents(
         chainIdBobaBnb,
         chainId,
         preBlockNumber,
-        blockNumber
+        blockNumber,
+        null,
+        lastDisbursement
       )
 
       console.log(

--- a/test/lightbridge.unit.spec.ts
+++ b/test/lightbridge.unit.spec.ts
@@ -606,7 +606,9 @@ describe('Asset Teleportation Tests', async () => {
           .to.emit(Proxy__Teleportation, 'AssetBalanceWithdrawn')
           .withArgs(L2Boba.address, signerAddress, partialAmount)
 
-        const newPreBalance = await L2Boba.balanceOf(Proxy__Teleportation.address)
+        const newPreBalance = await L2Boba.balanceOf(
+          Proxy__Teleportation.address
+        )
         await expect(
           Proxy__Teleportation.withdrawBalance(L2Boba.address, newPreBalance)
         )
@@ -1301,7 +1303,7 @@ describe('Asset Teleportation Tests', async () => {
         const gasFee = await getGasFeeFromLastestBlock(ethers.provider)
         expect(preBalance.sub(postBalance)).to.be.closeTo(
           postSignerBalance.sub(preSignerBalance),
-          postSignerBalance.sub(preSignerBalance).add(gasFee),
+          postSignerBalance.sub(preSignerBalance).add(gasFee)
         )
         expect(postBalance.toString()).to.be.eq('0')
       })


### PR DESCRIPTION
Query subgraphs via depositId instead of block range to improve reliability and avoid hitting the recovery mechanism. 